### PR TITLE
Refactor: 부모컴포넌트에서 isLiked를 Props로 전달하는 방법으로 수정 & 불필 요한 네트워크 요청 해결

### DIFF
--- a/src/components/Carousel/PosterHome/index.js
+++ b/src/components/Carousel/PosterHome/index.js
@@ -42,14 +42,15 @@ export const PosterCategory = ({ movie, onModalClick }) => {
   const isLogin = useRecoilValue(isLoginAtom);
   const [isLiked, setIsLiked] = useState(false);
 
-  const fetchMovieData = async () => {
-    const response = await getMovie(movie.id);
-    if (isLogin) {
-      setIsLiked(response.data.isLiked);
-    } else {
-      setIsLiked(false);
-    }
-  };
+  // const fetchMovieData = async () => {
+  //   const response = await getMovie(movie.id);
+  //   console.log(response);
+  //   if (isLogin) {
+  //     setIsLiked(response.data.isLiked);
+  //   } else {
+  //     setIsLiked(false);
+  //   }
+  // };
 
   const onClickLike = async (e) => {
     if (!isLogin) {
@@ -61,9 +62,9 @@ export const PosterCategory = ({ movie, onModalClick }) => {
 
   const onClick = () => onModalClick(movie?.id);
 
-  useEffect(() => {
-    fetchMovieData();
-  }, [movie.id]);
+  // useEffect(() => {
+  //   fetchMovieData();
+  // }, [movie.id]);
 
   return (
     <article className={styles.wrapperH}>
@@ -89,7 +90,8 @@ export const PosterCategory = ({ movie, onModalClick }) => {
               className={styles.iconH}
               onClick={onClickLike}
             >
-              {isLiked ? <SolidHeartIcon /> : <HeartIcon />}
+              {/* {isLiked ? <SolidHeartIcon /> : <HeartIcon />} */}
+              <HeartIcon />
             </Button>
           </div>
         </article>

--- a/src/components/Carousel/PosterHome/index.js
+++ b/src/components/Carousel/PosterHome/index.js
@@ -38,19 +38,9 @@ export const PosterRanking = ({
   );
 };
 
-export const PosterCategory = ({ movie, onModalClick }) => {
+export const PosterCategory = ({ movie, onModalClick, isLikedProp }) => {
   const isLogin = useRecoilValue(isLoginAtom);
-  const [isLiked, setIsLiked] = useState(false);
-
-  // const fetchMovieData = async () => {
-  //   const response = await getMovie(movie.id);
-  //   console.log(response);
-  //   if (isLogin) {
-  //     setIsLiked(response.data.isLiked);
-  //   } else {
-  //     setIsLiked(false);
-  //   }
-  // };
+  const [isLiked, setIsLiked] = useState(isLikedProp);
 
   const onClickLike = async (e) => {
     if (!isLogin) {
@@ -61,10 +51,6 @@ export const PosterCategory = ({ movie, onModalClick }) => {
   };
 
   const onClick = () => onModalClick(movie?.id);
-
-  // useEffect(() => {
-  //   fetchMovieData();
-  // }, [movie.id]);
 
   return (
     <article className={styles.wrapperH}>
@@ -90,8 +76,8 @@ export const PosterCategory = ({ movie, onModalClick }) => {
               className={styles.iconH}
               onClick={onClickLike}
             >
-              {/* {isLiked ? <SolidHeartIcon /> : <HeartIcon />} */}
-              <HeartIcon />
+              {isLiked ? <SolidHeartIcon /> : <HeartIcon />}
+              {/* <HeartIcon /> */}
             </Button>
           </div>
         </article>

--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -59,24 +59,24 @@ export const RankingCarousel = () => {
   useEffect(() => {
     fetchMoviesTop();
   }, []);
-  
+
   const modalVariants = {
     initial: {
       opacity: 0,
-      position: "fixed",
-      top: "-100vh",
-      left: "50%",
-      transform: "translate(-50%, 0) scale(0.8)",
+      position: 'fixed',
+      top: '-100vh',
+      left: '50%',
+      transform: 'translate(-50%, 0) scale(0.8)',
       transition: {
         duration: 0.2,
       },
     },
     visible: {
       opacity: 1,
-      position: "fixed",
-      top: "50%",
-      left: "50%",
-      transform: "translate(-50%, -50%) scale(1)",
+      position: 'fixed',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%) scale(1)',
       transition: {
         duration: 0.2,
         bounce: 0.9,
@@ -84,38 +84,37 @@ export const RankingCarousel = () => {
     },
     leaving: {
       opacity: 0,
-      position: "fixed",
-      top: "-100vh",
-      left: "50%",
-      transform: "translate(-50%, 0) scale(0.8)",
+      position: 'fixed',
+      top: '-100vh',
+      left: '50%',
+      transform: 'translate(-50%, 0) scale(0.8)',
       transition: {
         duration: 0.2,
       },
     },
   };
 
-
   return (
     <>
-     <AnimatePresence>
-      {isShow && (
-        <div className={styles.overlay} >
-           <motion.div
-            variants={modalVariants}
-            initial="initial"
-            animate="visible"
-            exit="leaving"
-            style={{zIndex : 999}}
-          >
-        <PreviewModal
-          onModalClose={onModalClose}
-          onModalClick={onModalClick}
-          movieId={movieId}
-        />
-         </motion.div>
-        </div>
-      )}
-    </AnimatePresence>
+      <AnimatePresence>
+        {isShow && (
+          <div className={styles.overlay}>
+            <motion.div
+              variants={modalVariants}
+              initial="initial"
+              animate="visible"
+              exit="leaving"
+              style={{ zIndex: 999 }}
+            >
+              <PreviewModal
+                onModalClose={onModalClose}
+                onModalClick={onModalClick}
+                movieId={movieId}
+              />
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
       <div className={styles.ranking}>
         <div className={styles.slider}>
           <Slider {...settings}>
@@ -182,62 +181,63 @@ export const HomeCarousel = ({ GenreId }) => {
   const modalVariants = {
     initial: {
       opacity: 0,
-      position: "fixed",
-      top: "-100vh",
-      left: "50%",
-      transform: "translate(-50%, 0) scale(0.8)",
+      position: 'fixed',
+      top: '-100vh',
+      left: '50%',
+      transform: 'translate(-50%, 0) scale(0.8)',
       transition: {
         duration: 0.2,
       },
     },
     visible: {
       opacity: 1,
-      position: "fixed",
-      top: "50%",
-      left: "50%",
-      transform: "translate(-50%, -50%) scale(1)",
+      position: 'fixed',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%) scale(1)',
       transition: {
         duration: 0.2,
       },
     },
     leaving: {
       opacity: 0,
-      position: "fixed",
-      top: "-100vh",
-      left: "50%",
-      transform: "translate(-50%, 0) scale(0.8)",
+      position: 'fixed',
+      top: '-100vh',
+      left: '50%',
+      transform: 'translate(-50%, 0) scale(0.8)',
       transition: {
         duration: 0.2,
       },
     },
   };
-
+  console.log(moviesGenre);
   return (
     <>
-     <AnimatePresence>
-      {isShow && (
-        <div className={styles.overlay} >
-           <motion.div
-            variants={modalVariants}
-            initial="initial"
-            animate="visible"
-            exit="leaving"
-            style={{zIndex : 999}}
-          >
-        <PreviewModal
-          onModalClose={onModalClose}
-          onModalClick={onModalClick}
-          movieId={movieId}
-        />
-         </motion.div>
-        </div>
-      )}
-    </AnimatePresence>
+      <AnimatePresence>
+        {isShow && (
+          <div className={styles.overlay}>
+            <motion.div
+              variants={modalVariants}
+              initial="initial"
+              animate="visible"
+              exit="leaving"
+              style={{ zIndex: 999 }}
+            >
+              <PreviewModal
+                onModalClose={onModalClose}
+                onModalClick={onModalClick}
+                movieId={movieId}
+              />
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
       <Slider {...settings}>
         {moviesGenre?.data.map((movie) => (
           <PosterCategory
             key={movie.id}
             movie={movie}
+            isLikedProp={movie.isLiked}
             onModalClick={onModalClick}
             movieId={movieId}
             callback={fetchMoviesGenre}

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,20 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import { RouterProvider } from "react-router-dom";
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
 
-import reportWebVitals from "./reportWebVitals";
-import rootRouter from "./router";
+import reportWebVitals from './reportWebVitals';
+import rootRouter from './router';
 
-import "./styles/global.scss";
-import { RecoilRoot } from "recoil";
+import './styles/global.scss';
+import { RecoilRoot } from 'recoil';
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
+const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <RecoilRoot>
     <React.StrictMode>
       <RouterProvider router={rootRouter} />
     </React.StrictMode>
-  </RecoilRoot>
+  </RecoilRoot>,
 );
 
 reportWebVitals();


### PR DESCRIPTION
기존 detail API요청하는 로직을 제거하고 
```typescript
 <PosterCategory
            key={movie.id}
            movie={movie}
            isLikedProp={movie.isLiked}
            onModalClick={onModalClick}
            movieId={movieId}
            callback={fetchMoviesGenre}
          />
```
isLikedProp을 추가했습니다. 

이후 useEffect가 movie.id에 의존하여 발생한  무수한 요청을 해결할 수 있었습니다. 


### 추가내용
formating에 관련된 수정 커밋들이 있습니다. 이부분 통일화하면 좋을 것 같습니다!
